### PR TITLE
Repeat main menu after backing out of move selection

### DIFF
--- a/cli_improved.py
+++ b/cli_improved.py
@@ -788,12 +788,11 @@ def _show_pokemon_showdown_menu(req: dict, battle: Dict[str, BattleSide], active
                 raise  # Re-raise to handle gracefully in main loop
     
     # Normal turn menu
-    print(f"\nWhat will {active_pokemon} do?")
-    print("  1. Fight")
-    print("  2. Pokemon")
-    
     while True:
         try:
+            print(f"\nWhat will {active_pokemon} do?")
+            print("  1. Fight")
+            print("  2. Pokemon")
             main_choice = input("\nChoose an option: ").strip()
             
             if main_choice == "1":  # Fight


### PR DESCRIPTION
## Summary
- reprint fight/pokemon options each time the turn menu loops so backing out shows the options again

## Testing
- `python -m py_compile cli_improved.py`


------
https://chatgpt.com/codex/tasks/task_e_68bffc8f1f1883218e7ed444e63f3674